### PR TITLE
Extracted 'Community FAQ' content to separate file

### DIFF
--- a/Community FAQ.md
+++ b/Community FAQ.md
@@ -1,0 +1,14 @@
+# :information_source: Community FAQ
+
+The information below is put together from various social media sources. (E.g. Reddit, Discord, ...)
+
+## :mage_man: ODAO
+* [What is the TL;DR of the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/804156484161896468)
+* [I heard that they can upgrade the smart contracts that the protocol uses- doesn't that mean they can steal deposited ETH?](https://discord.com/channels/405159462932971535/704196071881965589/820084833895448607)
+* [Why is the Oracle DAO necessary?](https://discord.com/channels/405159462932971535/704196071881965589/812111405263486996)
+* [When/how will we know who is in the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/812110740995178496)
+* [Why can't the Protocol DAO (RPL token holders) hold these responsibilites?](https://discord.com/channels/405159462932971535/704196071881965589/812112820350746644)
+
+## :moneybag: RPL
+* [What is the point of owning RPL?](https://www.reddit.com/r/ethstaker/comments/mwib11/rocketpool_community_resources/gvkik78?utm_source=share&utm_medium=web2x&context=3)
+* [Why isn't RPL currently listed on a major exchange like Coinbase?](https://discord.com/channels/405159462932971535/709960470953590825/834968369895047179)


### PR DESCRIPTION
Currently, the current main page is a bit long, while we're not even live yet. So to shorten its content without losing valuable information, I propose we put the Community FAQ contents into this separate file. When this change is accepted, we can adjust the main page to link to this one for community FAQ related content.

```
Section: New File - Community FAQ.md
Item: Community FAQ.md
Action: Add
```


**By submitting this pull request, I promise I've read the [contribution guidelines](https://github.com/isidorosp/awesome-rocketpool/blob/master/CONTRIBUTING.md).**