### PR TITLE
Replaced Community FAQ details on main page with link to separate page

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,17 +106,7 @@ Everyone is welcome to contribute to `awesome rocketpool`, as long as you follow
 
 ### :information_source: Community FAQ
 
-#### :mage_man: Community FAQ ODAO
-* [What is the TL;DR of the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/804156484161896468)
-* [I heard that they can upgrade the smart contracts that the protocol uses- doesn't that mean they can steal deposited ETH?](https://discord.com/channels/405159462932971535/704196071881965589/820084833895448607)
-* [Why is the Oracle DAO necessary?](https://discord.com/channels/405159462932971535/704196071881965589/812111405263486996)
-* [When/how will we know who is in the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/812110740995178496)
-* [Why can't the Protocol DAO (RPL token holders) hold these responsibilites?](https://discord.com/channels/405159462932971535/704196071881965589/812112820350746644)
-
-#### :moneybag: Community FAQ RPL
-* [What is the point of owning RPL?](https://www.reddit.com/r/ethstaker/comments/mwib11/rocketpool_community_resources/gvkik78?utm_source=share&utm_medium=web2x&context=3)
-* [Why isn't RPL currently listed on a major exchange like Coinbase?](https://discord.com/channels/405159462932971535/709960470953590825/834968369895047179)
-
+[Located On Separate Page](community-fAQ.md)
 
 ### :crossed_swords: Community Competitor Comparisons
 


### PR DESCRIPTION
In an earlier commit, these details were migrated to a separate page. After this change, there'll be no more duplicate data; all the Community FAQ details will be in a separate page and a link will be present on the main page for ease of access.

```
Section: Community - FAQ
Item: Link to separate page contains the same details
Action: Edit
```


**By submitting this pull request, I promise I've read the [contribution guidelines](https://github.com/isidorosp/awesome-rocketpool/blob/master/CONTRIBUTING.md).**