### PR TITLE
Categorize-Subcategories-By-Content-Instead-Of-Medium

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,120 +15,101 @@ Everyone is welcome to contribute to `awesome rocketpool`, as long as you follow
 
 ## Resources
 - [Official](#rocket-official)
-  - [Articles](#newspaper-official-articles)
-  - [Documentation](#books-official-documentation)
-  - [Social Media](#iphone-official-social-media)	
+  - [Explainer Series](#official-explainer-series)
+  - [Social Media](#social-media)	
 - [Press](#detective-press)
-  - [Articles](#newspaper-press-articles) 
-  - [Videos](#tv-press-videos)  
 - [Community](#speak_no_evil-community)
-  - [Articles](#newspaper-community-articles) 
-  - [Guides](#bookmark_tabs-community-guides)
-  - [Tools](#hammer_and_wrench-community-tools)
-  - [Videos](#tv-community-videos)
-  - [FAQ](#information_source-community-faq)
-  - [Competitor Comparisons](#crossed_swords-community-competitor-comparisons)
+  - [Investment Opinions](#investment-opinions) 
+  - [Explainer Series](#community-explainer-series)
+  - [Guides](#guides)
+  - [Tools](#tools)
+  - [FAQ](#faq)
+  - [Competitor Comparisons](#competitor-comparisons)
 - [Misc](#alien-misc)
-  - [Market information](#chart_with_upwards_trend-market-information) 
-  - [Eth2 Clients](#computer-eth2-clients)
+  - [Market information](#market-information) 
+  - [Eth2 Clients](#eth2-clients)
 ---
 
 ## :rocket: Official
-* [Website](https://www.rocketpool.net)
+* :globe_with_meridians: [Website](https://www.rocketpool.net)
+* :newspaper: [Whitepaper](https://www.rocketpool.net/files/RocketPoolWhitePaper.pdf)
+* :newspaper: [Docs](https://rocket-pool.readthedocs.io/en/latest/)
+* :newspaper: [FAQ](https://medium.com/rocket-pool/rocket-pool-101-faq-ee683af10da9)
 
-### :newspaper: Official Articles
-* [Explainer Series Part 1 - Overview And Users](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-1-8be4859e5fbd)
-* [Explainer Series Part 2 - The Oracle Node And Protocol DAO's](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-2-e0d346911fe1)
-* [Explainer Series Part 3 - RPL & Tokenomics](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-3-3029afb57d4c)
+### Official Explainer Series
+* :newspaper: [Explainer Series Part 1 - Overview And Users](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-1-8be4859e5fbd)
+* :newspaper: [Explainer Series Part 2 - The Oracle Node And Protocol DAO's](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-2-e0d346911fe1)
+* :newspaper: [Explainer Series Part 3 - RPL & Tokenomics](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-3-3029afb57d4c)
 
-### :books: Official Documentation
-* [Whitepaper](https://www.rocketpool.net/files/RocketPoolWhitePaper.pdf)
-* [Docs](https://rocket-pool.readthedocs.io/en/latest/)
-* [FAQ](https://medium.com/rocket-pool/rocket-pool-101-faq-ee683af10da9)
-
-### :iphone: Official Social Media
-* [Discord](https://discord.com/invite/tCRG54c)
-* [Twitter](https://twitter.com/Rocket_Pool)
-* [Reddit](https://www.reddit.com/r/rocketpool/)
-* [Medium](https://medium.com/rocket-pool)
-* [Github](https://github.com/rocket-pool/rocketpool) 
+### Social Media
+* :iphone: [Discord](https://discord.com/invite/tCRG54c)
+* :iphone: [Twitter](https://twitter.com/Rocket_Pool)
+* :iphone: [Reddit](https://www.reddit.com/r/rocketpool/)
+* :iphone: [Medium](https://medium.com/rocket-pool)
+* :iphone: [Github](https://github.com/rocket-pool/rocketpool) 
 
 ---
 
 ## :detective: Press
 
-### :newspaper: Press Articles
-
-* [Bankless Newsletter - How Ethereum Can Democratize ETH2 Staking](https://newsletter.banklesshq.com/p/how-ethereum-can-democratize-eth2)
-* [Crypto Briefing - Defi Project Spotlight - Rocket Pool, Staking Service for Ethereum 2.0](https://cryptobriefing.com/defi-project-spotlight-rocket-pool-staking-service-ethereum-2-0/)
-* [Shrimpy Academy - What Is Rocket Pool?](https://academy.shrimpy.io/post/what-is-rocket-pool)
-
-
-### :tv: Press Videos
-
-* [Interview w/ CTO David Rugendyke - Bankless](https://www.youtube.com/watch?v=cqf6aJCFZn8)
+* :newspaper: [Bankless Newsletter - How Ethereum Can Democratize ETH2 Staking](https://newsletter.banklesshq.com/p/how-ethereum-can-democratize-eth2)
+* :newspaper: [Crypto Briefing - Defi Project Spotlight - Rocket Pool, Staking Service for Ethereum 2.0](https://cryptobriefing.com/defi-project-spotlight-rocket-pool-staking-service-ethereum-2-0/)
+* :newspaper: [Shrimpy Academy - What Is Rocket Pool?](https://academy.shrimpy.io/post/what-is-rocket-pool)
+* :tv: [Bankless - Interview w/ CTO David Rugendyke](https://www.youtube.com/watch?v=cqf6aJCFZn8)
 
 ---
 
 ## :speak_no_evil: Community
 
-### :newspaper: Community Articles
+### Investment Opinions
 
-* [Rocket Pool Investment Thesis - Original](https://www.reddit.com/r/ethfinance/comments/m3pug8/the_rocket_pool_investment_thesis/)
-* [Rocket Pool Investment Thesis - Speculative Edition](https://www.reddit.com/r/ethtrader/comments/m43r38/the_rocket_pool_investment_thesis_speculative/)
-* [Rocket Pool Investment Thesis - Price To Earnings Ratio](https://www.reddit.com/r/ethfinance/comments/m4jj0i/rocketpool_investment_thesis_round_3/)
+* :newspaper: [Rocket Pool Investment Thesis - Original](https://www.reddit.com/r/ethfinance/comments/m3pug8/the_rocket_pool_investment_thesis/)
+* :newspaper: [Rocket Pool Investment Thesis - Speculative Edition](https://www.reddit.com/r/ethtrader/comments/m43r38/the_rocket_pool_investment_thesis_speculative/)
+* :newspaper: [Rocket Pool Investment Thesis - Price To Earnings Ratio](https://www.reddit.com/r/ethfinance/comments/m4jj0i/rocketpool_investment_thesis_round_3/)
+* :tv: [Rocket Pool Tokenomics - Ethstaker Livestream](https://www.youtube.com/watch?v=cIXWF512srA)
 
-### :bookmark_tabs: Community Guides
+### Community Explainer Series
 
-#### :computer: Node Operator Community Guides
-* [Node Operator’s Guide](https://medium.com/rocket-pool/rocket-pool-v2-5-beta-node-operators-guide-77859891766b)
-* [Setting up Rocket Pool on a Raspberry Pi](https://github.com/jclapis/rp-pi-guide/blob/main/Overview.md)
-* [Selecting Staking Hardware](https://github.com/jclapis/rocketpool.github.io/blob/main/src/guides/local/hardware.md)
-* [Guide To Setup Grafana Dashboard](https://github.com/yorickdowne/grafana-for-rpool)
+* :tv: [Rocket Pool Explainer Series: Part One - Logic Beach](https://www.youtube.com/watch?v=uytfJlMfdyc)
+* :tv: [Rocket Pool Explainer Series: Part Two - Logic Beach](https://www.youtube.com/watch?v=Vc4rxI9zEis)
 
-#### rETH Staker Community Guides
+### Guides
 
-* [ ] TODO
+#### Node Operator Guides
+* :newspaper: [Node Operator’s Guide](https://medium.com/rocket-pool/rocket-pool-v2-5-beta-node-operators-guide-77859891766b)
+* :newspaper: [Setting up Rocket Pool on a Raspberry Pi](https://github.com/jclapis/rp-pi-guide/blob/main/Overview.md)
+* :newspaper: [Selecting Staking Hardware](https://github.com/jclapis/rocketpool.github.io/blob/main/src/guides/local/hardware.md)
+* :newspaper: [Guide To Setup Grafana Dashboard](https://github.com/yorickdowne/grafana-for-rpool)
+* :newspaper: [Decentralized Graffiti Drawing](https://github.com/RomiRand/DecentralizedGraffitiDrawing)
+  - :tv: [Demo](https://www.youtube.com/watch?v=TdzfX0df-F0&ab_channel=ETHStaker)
 
-### :hammer_and_wrench: Community Tools
+#### rETH Staker Guides
 
-* [Rocket Pool Tool](https://www.rocketpooltool.com/)
-* [Decentralized Graffiti Drawing](https://github.com/RomiRand/DecentralizedGraffitiDrawing)
-* [RPL Calculator (Spreadsheet)](https://docs.google.com/spreadsheets/d/1Wl3EukDALcd8nBQQkMhzXr5WfwmEj264YPfch9AJN30/edit#gid=0)
-* [Rocket Pool Beta 3 Leaderboard](https://rpl-beta-3-leaderboard-frl9u.ondigitalocean.app/)
-* [ ] TODO (Node Operator Dashboard - by beaconcha.in)
+* :newspaper: TODO - rEth Staker Guide #1
 
-### :tv: Community Videos
+### Tools
 
-* [Rocket Pool Tokenomics - Ethstaker Livestream](https://www.youtube.com/watch?v=cIXWF512srA)
-* [Rocket Pool Explainer Series: Part One - Logic Beach](https://www.youtube.com/watch?v=uytfJlMfdyc)
-* [Rocket Pool Explainer Series: Part Two - Logic Beach](https://www.youtube.com/watch?v=Vc4rxI9zEis)
+* :hammer_and_wrench: [Rocket Pool Tool (Website With Built-In Calculator)](https://www.rocketpooltool.com/)
+* :hammer_and_wrench: [RPL Calculator (Spreadsheet)](https://docs.google.com/spreadsheets/d/1Wl3EukDALcd8nBQQkMhzXr5WfwmEj264YPfch9AJN30/edit#gid=0)
+* :trophy: [Rocket Pool Beta 3 Leaderboard](https://rpl-beta-3-leaderboard-frl9u.ondigitalocean.app/)
+* :chart: Node Operator Dashboard - by beaconcha.in (In Development)
 
-### :information_source: Community FAQ
+### FAQ
 
-#### :mage_man: Community FAQ ODAO
-* [What is the TL;DR of the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/804156484161896468)
-* [I heard that they can upgrade the smart contracts that the protocol uses- doesn't that mean they can steal deposited ETH?](https://discord.com/channels/405159462932971535/704196071881965589/820084833895448607)
-* [Why is the Oracle DAO necessary?](https://discord.com/channels/405159462932971535/704196071881965589/812111405263486996)
-* [When/how will we know who is in the Oracle DAO?](https://discord.com/channels/405159462932971535/704196071881965589/812110740995178496)
-* [Why can't the Protocol DAO (RPL token holders) hold these responsibilites?](https://discord.com/channels/405159462932971535/704196071881965589/812112820350746644)
+[Located On Separate Page](community-fAQ.md)
 
-#### :moneybag: Community FAQ RPL
-* [What is the point of owning RPL?](https://www.reddit.com/r/ethstaker/comments/mwib11/rocketpool_community_resources/gvkik78?utm_source=share&utm_medium=web2x&context=3)
-* [Why isn't RPL currently listed on a major exchange like Coinbase?](https://discord.com/channels/405159462932971535/709960470953590825/834968369895047179)
+### Competitor Comparisons
 
-
-### :crossed_swords: Community Competitor Comparisons
-
-* [ ] TODO
+* :crossed_swords: TODO Competitor Comparison #1
 
 ---
 
 ## :alien: Misc
 
-### :chart_with_upwards_trend: Market information
-* [CoinGecko](https://www.coingecko.com/en/coins/rocket-pool)
+### Market information
 
-### :computer: Eth2 Clients
+* :chart_with_upwards_trend: [CoinGecko](https://www.coingecko.com/en/coins/rocket-pool)
 
-* [ ] TODO
+### Eth2 Clients
+
+* :computer: TODO


### PR DESCRIPTION
Due to pull request 'VGR-GIT-Added-Decentralized-Graffiti-Drawing-Tool--Demo-link', I've put together a small rework of the main page, where the subcategories (everything directly under Official, Press, Community, Misc) are now no longer mediums (e.g. article, video, ...) but represent a group of similar content. (E.g. Community - Investment Opinions, Community - Guides, ...)

I've changed the icons so they are now on items directly under either a h<X> element. This way we could have the 'best of both worlds', because we can now indicate if an item is an article or a video. This used to be indicated by its parent category.

```
Section: Multiple - See Description
Item: Multiple - See Description
Action: Edit
```


**By submitting this pull request, I promise I've read the [contribution guidelines](https://github.com/isidorosp/awesome-rocketpool/blob/master/CONTRIBUTING.md).**