### PR TITLE
Split up Tools (Official & Community) & Added Glossary

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Everyone is welcome to contribute to `awesome rocketpool`, as long as you follow
 * :newspaper: [Docs](https://rocket-pool.readthedocs.io/en/latest/)
 * :newspaper: [FAQ](https://medium.com/rocket-pool/rocket-pool-101-faq-ee683af10da9)
 * :newspaper: [DAO Forums](https://dao.rocketpool.net/)
+* :newspaper: [Glossary](https://github.com/htimsk/rocketpool.github.io/blob/main/src/documentation/glossary.md)
 
 ### Official Explainer Series
 * :newspaper: [Explainer Series Part 1 - Overview And Users](https://medium.com/rocket-pool/rocket-pool-staking-protocol-part-1-8be4859e5fbd)
@@ -48,6 +49,10 @@ Everyone is welcome to contribute to `awesome rocketpool`, as long as you follow
 * :iphone: [Reddit](https://www.reddit.com/r/rocketpool/)
 * :iphone: [Medium](https://medium.com/rocket-pool)
 * :iphone: [Github](https://github.com/rocket-pool/rocketpool) 
+
+### Official Tools
+
+* :hammer_and_wrench: [RPL Calculator (Spreadsheet)](https://docs.google.com/spreadsheets/d/1Wl3EukDALcd8nBQQkMhzXr5WfwmEj264YPfch9AJN30/edit#gid=0)
 
 ---
 
@@ -88,10 +93,9 @@ Everyone is welcome to contribute to `awesome rocketpool`, as long as you follow
 
 * :newspaper: TODO - rEth Staker Guide #1
 
-### Tools
+### Community Tools
 
 * :hammer_and_wrench: [Rocket Pool Tool (Website With Built-In Calculator)](https://www.rocketpooltool.com/)
-* :hammer_and_wrench: [RPL Calculator (Spreadsheet)](https://docs.google.com/spreadsheets/d/1Wl3EukDALcd8nBQQkMhzXr5WfwmEj264YPfch9AJN30/edit#gid=0)
 * :hammer_and_wrench: [Rocket Pool Gas Estimates](https://docs.google.com/spreadsheets/d/1KhAhByZ4JbJxdVfhSoKzZvjvUKuSXnB9alJS8FmbtA4/edit?usp=sharing)
 * :trophy: [Rocket Pool Beta 3 Leaderboard](https://rpl-beta-3-leaderboard-frl9u.ondigitalocean.app/)
 * :chart: Node Operator Dashboard - by beaconcha.in (In Development)


### PR DESCRIPTION
I've had some input (from Ken) that he couldn't find the RPL Calculator provided by the team, even though it was listed as a community tool. That's why this is my proposal; we have 3 main sources of content (Official, Press & Community) & if one of the subsections/categories is present under multiple sources of content, e.g. Explainer Series, then we add some context to it and move items to their correct place. In this PR this translates itself into adding more context to the existing 'Tools' subsection/category, so after this PR we have 'Community Tools' and 'Official Tools'. Under 'Official Tools' users will be able to find the official RPL calculator sheet.

As a minor change, I've also added the official glossary of RocketPool.

```
Section: Community Tools, Official Tools
Item: Glossary, RPL Calculator
Action: Add/Edit
```


**By submitting this pull request, I promise I've read the [contribution guidelines](https://github.com/isidorosp/awesome-rocketpool/blob/master/CONTRIBUTING.md).**